### PR TITLE
HFX-1715: Backport of the TLS 1.2 support to XS 6.5 SP1

### DIFF
--- a/SOURCES/vhd-tool-tlsv12.patch
+++ b/SOURCES/vhd-tool-tlsv12.patch
@@ -1,0 +1,155 @@
+diff --git a/src/channels.ml b/src/channels.ml
+index 81fa8173a1762197de41901fa4f38066c402955b..445ed05e42b20beedde3ec30062389cd53ebff62 100644
+--- a/src/channels.ml
++++ b/src/channels.ml
+@@ -49,11 +49,24 @@ let of_seekable_fd fd =
+     return () in
+   return { c with skip }
+ 
+-let sslctx =
+-  Ssl.init ();
+-  Ssl.create_context Ssl.SSLv23 Ssl.Client_context
++let _ =
++  Ssl.init ()
+ 
+-let of_ssl_fd fd =
++let legacy_sslctx good_ciphersuites legacy_ciphersuites =
++  let ctx = Ssl.create_context Ssl.SSLv23 Ssl.Client_context in
++  Ssl.set_cipher_list ctx (good_ciphersuites ^ (match legacy_ciphersuites with "" -> "" | s -> (":" ^ s)));
++  Ssl.disable_protocols ctx [Ssl.SSLv3];
++  ctx
++
++let good_sslctx good_ciphersuites =
++  let ctx = Ssl.create_context Ssl.TLSv1_2 Ssl.Client_context in
++  Ssl.set_cipher_list ctx good_ciphersuites;
++  ctx
++
++let of_ssl_fd fd ssl_legacy good_ciphersuites legacy_ciphersuites =
++  let good_ciphersuites = match good_ciphersuites with None -> failwith "good_ciphersuites not specified" | Some x -> x in
++  let legacy_ciphersuites = match legacy_ciphersuites with None -> failwith "legacy_ciphersuites not specified" | Some x -> x in
++  let sslctx = if ssl_legacy then legacy_sslctx good_ciphersuites legacy_ciphersuites else good_sslctx good_ciphersuites in
+   Lwt_ssl.ssl_connect fd sslctx >>= fun sock ->
+   let offset = ref 0L in
+   let really_read buf =
+diff --git a/src/impl.ml b/src/impl.ml
+index d31c426a684990e5a493bbaecc8db67fbacebe25..deedfb3dcd11e1a18de342a86b4445c68c075885 100644
+--- a/src/impl.ml
++++ b/src/impl.ml
+@@ -643,7 +643,7 @@ let make_stream common source relative_to source_format destination_format =
+     Raw_input.raw t
+   | _, _ -> assert false
+ 
+-let write_stream common s destination source_protocol destination_protocol prezeroed progress tar_filename_prefix = 
++let write_stream common s destination source_protocol destination_protocol prezeroed progress tar_filename_prefix ssl_legacy good_ciphersuites legacy_ciphersuites = 
+   endpoint_of_string destination >>= fun endpoint ->
+   let use_ssl = match endpoint with Https _ -> true | _ -> false in
+   ( match endpoint with
+@@ -677,7 +677,7 @@ let write_stream common s destination source_protocol destination_protocol preze
+       Lwt_unix.connect sock sockaddr >>= fun () ->
+ 
+       let open Cohttp in
+-      ( if use_ssl then Channels.of_ssl_fd sock else Channels.of_raw_fd sock ) >>= fun c ->
++      ( if use_ssl then Channels.of_ssl_fd sock ssl_legacy good_ciphersuites legacy_ciphersuites else Channels.of_raw_fd sock ) >>= fun c ->
+   
+       let module Request = Request.Make(Cohttp_unbuffered_io) in
+       let module Response = Response.Make(Cohttp_unbuffered_io) in
+@@ -760,7 +760,7 @@ let write_stream common s destination source_protocol destination_protocol preze
+ 
+ let stream_t common args ?(progress = no_progress_bar) () =
+   make_stream common args.StreamCommon.source args.StreamCommon.relative_to args.StreamCommon.source_format args.StreamCommon.destination_format >>= fun s ->
+-  write_stream common s args.StreamCommon.destination args.StreamCommon.source_protocol args.StreamCommon.destination_protocol args.StreamCommon.prezeroed progress args.StreamCommon.tar_filename_prefix
++  write_stream common s args.StreamCommon.destination args.StreamCommon.source_protocol args.StreamCommon.destination_protocol args.StreamCommon.prezeroed progress args.StreamCommon.tar_filename_prefix args.StreamCommon.ssl_legacy args.StreamCommon.good_ciphersuites args.StreamCommon.legacy_ciphersuites
+ 
+ let stream common args =
+   try
+diff --git a/src/main.ml b/src/main.ml
+index a5b254b3f79df42ae39df16eac294c59c5d27ec5..62a6b77026eb68896d52da9d5ec184289051bc8e 100644
+--- a/src/main.ml
++++ b/src/main.ml
+@@ -162,6 +162,18 @@ let tar_filename_prefix =
+   let doc = "Filename prefix for tar/sha disk blocks" in
+   Arg.(value & opt (some string) None & info ["tar-filename-prefix"] ~doc)
+ 
++let ssl_legacy =
++  let doc = "SSL legacy flag for TLS protocols" in
++  Arg.(value & flag & info ["ssl-legacy"] ~doc)
++
++let good_ciphersuites =
++  let doc = "The list of ciphersuites to allow for TLS" in
++  Arg.(value & opt (some string) None & info ["good-ciphersuites"] ~doc)
++
++let legacy_ciphersuites =
++  let doc = "Additional TLS ciphersuites allowed only if ssl-legacy is set" in
++  Arg.(value & opt (some string) None & info ["legacy-ciphersuites"] ~doc)
++
+ let serve_cmd =
+   let doc = "serve the contents of a disk" in
+   let man = [
+@@ -231,7 +243,7 @@ let stream_cmd =
+     let doc = "Transport protocol for the destination data." in
+     Arg.(value & opt (some string) None & info [ "destination-protocol" ] ~doc) in
+   let stream_args_t =
+-    Term.(pure StreamCommon.make $ source $ relative_to $ source_format $ destination_format $ destination $ destination_fd $ source_protocol $ destination_protocol $ prezeroed $ progress $ machine $ tar_filename_prefix) in
++    Term.(pure StreamCommon.make $ source $ relative_to $ source_format $ destination_format $ destination $ destination_fd $ source_protocol $ destination_protocol $ prezeroed $ progress $ machine $ tar_filename_prefix $ ssl_legacy $ good_ciphersuites $ legacy_ciphersuites) in
+   Term.(ret(pure Impl.stream $ common_options_t $ stream_args_t)),
+   Term.info "stream" ~sdocs:_common_options ~doc ~man
+ 
+diff --git a/src/sparse_dd.ml b/src/sparse_dd.ml
+index a445bdc9f3601856f9383c4949201cf46d17d378..6b964a412ff06d738efbaf7578456bb98b7289c6 100644
+--- a/src/sparse_dd.ml
++++ b/src/sparse_dd.ml
+@@ -40,6 +40,10 @@ let set_machine_logging = ref false
+ let experimental_reads_bypass_tapdisk = ref false
+ let experimental_writes_bypass_tapdisk = ref false
+ 
++let ssl_legacy = ref true
++let good_ciphersuites = ref None
++let legacy_ciphersuites = ref None
++
+ let string_opt = function
+   | None -> "None"
+   | Some x -> x
+@@ -65,6 +69,9 @@ let options =
+     "size", Arg.String (fun x -> size := Int64.of_string x), (fun () -> Int64.to_string !size), "number of bytes to copy";
+     "prezeroed", Arg.Set prezeroed, (fun () -> string_of_bool !prezeroed), "assume the destination disk has been prezeroed";
+     "machine", Arg.Set machine_readable_progress, (fun () -> string_of_bool !machine_readable_progress), "emit machine-readable output";
++    "ssl-legacy", Arg.Set ssl_legacy, (fun () -> string_of_bool !ssl_legacy), " ssl legacy flag";
++    "good-ciphersuites", Arg.String (fun x -> good_ciphersuites := Some x), (fun () -> string_opt !good_ciphersuites), " ssl good ciphers";
++    "legacy-ciphersuites", Arg.String (fun x -> legacy_ciphersuites := Some x), (fun () -> string_opt !legacy_ciphersuites), " ssl legacy ciphers";
+ ]
+ 
+ open Xenstore
+@@ -380,7 +387,7 @@ let _ =
+           progress_cb fraction in
+         let t =
+         	stream_t >>= fun s ->
+-		Impl.write_stream common s destination (Some "none") None !prezeroed progress None in
++		Impl.write_stream common s destination (Some "none") None !prezeroed progress None !ssl_legacy !good_ciphersuites !legacy_ciphersuites in
+ 	if destination_format = "vhd"
+ 	then with_paused_tapdisk dest (fun () -> Lwt_main.run t)
+ 	else Lwt_main.run t;
+diff --git a/src/streamCommon.ml b/src/streamCommon.ml
+index c827023f28e4575c7363ba53e822fb27376cc39a..6ccef0149e45550ab07a567b20719390ac623db3 100644
+--- a/src/streamCommon.ml
++++ b/src/streamCommon.ml
+@@ -41,9 +41,12 @@ type t = {
+   progress: bool;
+   machine: bool;
+   tar_filename_prefix: string option;
++  ssl_legacy: bool;
++  good_ciphersuites: string option;
++  legacy_ciphersuites: string option;
+ }
+ 
+-let make source relative_to source_format destination_format destination destination_fd source_protocol destination_protocol prezeroed progress machine tar_filename_prefix =
++let make source relative_to source_format destination_format destination destination_fd source_protocol destination_protocol prezeroed progress machine tar_filename_prefix ssl_legacy good_ciphersuites legacy_ciphersuites =
+   let source_protocol = protocol_of_string (require "source-protocol" source_protocol) in
+   let destination_protocol = match destination_protocol with
+     | None -> None
+@@ -56,5 +59,5 @@ let make source relative_to source_format destination_format destination destina
+     | None -> destination
+     | Some fd -> "fd://" ^ (string_of_int fd) in
+ 
+-  { source; relative_to; source_format; destination_format; destination; source_protocol; destination_protocol; prezeroed; progress; machine; tar_filename_prefix }
++  { source; relative_to; source_format; destination_format; destination; source_protocol; destination_protocol; prezeroed; progress; machine; tar_filename_prefix; ssl_legacy; good_ciphersuites; legacy_ciphersuites }
+ 

--- a/message-switch.spec
+++ b/message-switch.spec
@@ -15,7 +15,7 @@ Requires(preun): initscripts
 BuildRequires: ocaml-cohttp-devel ocaml-rpc-devel ocaml-xenstore-devel
 BuildRequires: ocaml-ounit-devel ocaml-uri-devel
 BuildRequires: ocaml-re-devel ocaml-rpc-devel cmdliner-devel
-BuildRequires: ocaml-ssl-devel ocaml-oclock-devel
+BuildRequires: ocaml-ssl-devel ocaml-oclock-devel ocaml-bytes-devel
 BuildRequires: openssl-xs openssl-xs-devel
 BuildRequires: ocaml-lwt-devel ocaml-type-conv xmlm-devel
 Requires:      redhat-lsb-core

--- a/ocaml-bytes.spec
+++ b/ocaml-bytes.spec
@@ -1,0 +1,47 @@
+Name:           ocaml-bytes
+Version:        1.4
+Release:        1%{?extrarelease}
+Summary:        Bytes module for ocaml <= 4.02
+License:        ISC
+Group:          Development/Other
+URL:            https://github.com/chambart/ocaml-bytes
+Source0:        https://github.com/chambart/ocaml-bytes/archive/ocaml-bytes.1.4.tar.gz
+BuildRoot:      %{_tmppath}/%{name}-%{version}-%{release}
+BuildRequires:  ocaml ocaml-findlib ocaml-ocamldoc ocaml-re-devel ocaml-compiler-libs
+Requires:       ocaml ocaml-findlib
+
+%description
+Bytes module for ocaml <= 4.02
+
+%package        devel
+Summary:        Development files for %{name}
+Group:          Development/Other
+
+%description    devel
+The %{name}-devel package contains libraries and signature files for
+developing applications that use %{name}.
+
+%prep
+%setup -q -n %{name}-%{name}.%{version}
+
+%build
+./configure
+make
+
+%install
+rm -rf %{buildroot}
+mkdir -p %{buildroot}/%{_libdir}/ocaml/bytes
+make install LIBDIR=%{buildroot}/%{_libdir}/ocaml/bytes
+
+%clean
+rm -rf %{buildroot}
+
+%files devel
+%defattr(-,root,root)
+%doc README.md
+%{_libdir}/ocaml/bytes/*
+
+%changelog
+* Thu May 26 2016 Phus Lu <phus.lu@citrix.com>
+- Initial package
+

--- a/ocaml-cohttp.spec
+++ b/ocaml-cohttp.spec
@@ -9,7 +9,7 @@ Source0:        https://github.com/mirage/%{name}/archive/%{name}-%{version}/%{n
 BuildRoot:      %{_tmppath}/%{name}-%{version}-%{release}
 BuildRequires:  ocaml ocaml-findlib ocaml-re-devel ocaml-uri-devel ocaml-cstruct-devel ocaml-lwt-devel ocaml-ounit-devel ocaml-ocamldoc ocaml-camlp4-devel
 # should these be inherited from ssl.spec somehow?
-BuildRequires:  openssl-xs openssl-xs-devel ocaml-ocplib-endian-devel ocaml-ssl-devel
+BuildRequires:  openssl-xs openssl-xs-devel ocaml-ocplib-endian-devel ocaml-ssl-devel ocaml-bytes-devel
 Requires:       ocaml ocaml-findlib
 
 %description

--- a/ocaml-lwt.spec
+++ b/ocaml-lwt.spec
@@ -24,7 +24,7 @@ BuildRequires:  ocaml-react-devel >= 0.9.0
 BuildRequires:  ocaml-ocamldoc
 BuildRequires:  ocaml-text-devel
 BuildRequires:  ocaml-camlp4 ocaml-camlp4-devel
-BuildRequires:  ocaml-ssl-devel
+BuildRequires:  ocaml-ssl-devel ocaml-bytes-devel
 BuildRequires:  ocaml-compiler-libs
 
 %description

--- a/ocaml-ssl.spec
+++ b/ocaml-ssl.spec
@@ -1,13 +1,13 @@
 Name:           ocaml-ssl
-Version:        0.4.6
-Release:        2%{?extrarelease}
+Version:        0.5.2
+Release:        1%{?extrarelease}
 Summary:        Use OpenSSL from OCaml
 License:        LGPL
 Group:          Development/Other
-URL:            http://downloads.sourceforge.net/project/savonet/ocaml-ssl/0.4.6/ocaml-ssl-0.4.6.tar.gz
+URL:            http://downloads.sourceforge.net/project/savonet/ocaml-ssl
 Source0:        http://downloads.sourceforge.net/project/savonet/%{name}/%{version}/%{name}-%{version}.tar.gz
 BuildRoot:      %{_tmppath}/%{name}-%{version}-%{release}
-BuildRequires:  ocaml ocaml-findlib openssl-xs-devel openssl-wrapper
+BuildRequires:  ocaml ocaml-findlib openssl-xs-devel openssl-wrapper autoconf automake ocaml-bytes-devel
 Requires:       ocaml ocaml-findlib openssl-xs openssl-wrapper
 
 %description
@@ -25,6 +25,7 @@ developing applications that use %{name}.
 %setup -q
 
 %build
+./bootstrap
 ./configure
 # --disable-ldconf
 make
@@ -42,7 +43,7 @@ rm -rf %{buildroot}
 
 %files devel
 %defattr(-,root,root)
-%doc CHANGES COPYING README
+%doc CHANGES COPYING README.md
 %{_libdir}/ocaml/ssl/*
 %{_libdir}/ocaml/stublibs/dllssl_stubs.so
 %{_libdir}/ocaml/stublibs/dllssl_stubs.so.owner
@@ -51,6 +52,9 @@ rm -rf %{buildroot}
 %{_libdir}/ocaml/stublibs/dllssl_threads_stubs.so.owner
 
 %changelog
+* Tue May 24 2016 Phus Lu <phus.lu@citrix.com> - 0.5.2-1
+- Upgrade to ocaml-ssl-0.5.2 for TLSv1.2
+
 * Mon Dec 14 2015 Si Beaumont <simon.beaumont@citrix.com> - 0.4.6-2
 - Recompile against openssl-xs
 

--- a/vhd-tool.spec
+++ b/vhd-tool.spec
@@ -3,12 +3,13 @@
 Summary: command-line tools for manipulating and streaming .vhd format files
 Name:    vhd-tool
 Version: 0.7.4
-Release: 2
+Release: 3
 Group:   System/Hypervisor
 License: LGPL+linking exception
 URL:  http://www.xen.org
 Source0: https://github.com/xapi-project/vhd-tool/archive/v%{version}/vhd-tool-%{version}.tar.gz
 Source1: vhd-tool-sparse_dd-conf
+Patch0: vhd-tool-tlsv12.patch
 BuildRoot: %{_tmppath}/%{name}-%{version}-root
 BuildRequires: ocaml ocaml-findlib ocaml-camlp4-devel ocaml-ocamldoc
 BuildRequires: ocaml-ipaddr-devel
@@ -31,6 +32,7 @@ Simple command-line tools for manipulating and streaming .vhd format file.
 
 %prep 
 %setup -q
+%patch0 -p1 -b .tlsv12
 cp %{SOURCE1} vhd-tool-sparse_dd-conf
 
 
@@ -56,6 +58,9 @@ rm -rf %{buildroot}
 /opt/xensource/libexec/sparse_dd
 
 %changelog
+* Fri May 27 2016 Phus Lu <phus.lu@citrix.com> - 0.7.4-3
+- Add vhd-tool-tlsv12.patch
+
 * Mon Dec 14 2015 Si Beaumont <simon.beaumont@citrix.com> - 0.7.4-2
 - Recompile against openssl-xs
 

--- a/vhd-tool.spec
+++ b/vhd-tool.spec
@@ -17,7 +17,7 @@ BuildRequires: ocaml-io-page-devel
 BuildRequires: ocaml-ocplib-endian-devel
 BuildRequires: ocaml-xcp-idl-devel ocaml-vhd-devel ocaml-obuild
 BuildRequires: ocaml-nbd-devel ocaml-cstruct-devel ocaml-lwt-devel
-BuildRequires: ocaml-ounit-devel ocaml-rpc-devel ocaml-ssl-devel ocaml-stdext-devel
+BuildRequires: ocaml-ounit-devel ocaml-rpc-devel ocaml-ssl-devel ocaml-stdext-devel ocaml-bytes-devel
 BuildRequires: ocaml-sha-devel
 BuildRequires: ocaml-tapctl-devel
 BuildRequires: ocaml-tar-devel


### PR DESCRIPTION
This is for TLS1.2 HFX on LCM branches.

These commits originated on trunk and then was backported to cream-lcm branch, now cherry-picked from cream-lcm to cream-bugfix branch.

@thomassa , would you kindly review this?
