### PR TITLE
CA-244698: backport CA-218219 fix: precheck index range before accessing 

### DIFF
--- a/SOURCES/ocaml-vhd-CA-218219.patch
+++ b/SOURCES/ocaml-vhd-CA-218219.patch
@@ -1,0 +1,31 @@
+From 603ea4d8bb0b101b7efa30ccb7ed22028cd4ffbe Mon Sep 17 00:00:00 2001
+From: Zheng Li <zheng.li3@citrix.com>
+Date: Wed, 7 Sep 2016 17:52:01 +0100
+Subject: [PATCH] CA-218219: precheck index range before accessing
+
+This is similar to the CA-139732 case fixed previously, just a different
+occurence. Basically, when there is a chain of VHDs of different sizes (i.e.
+there was resize operation in history), we'd better check if the index is in
+range before accessing the data.
+
+Signed-off-by: Zheng Li <zheng.li3@citrix.com>
+---
+ lib/f.ml | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/lib/f.ml b/lib/f.ml
+index 620600f..7da5452 100644
+--- a/lib/f.ml
++++ b/lib/f.ml
+@@ -2073,7 +2073,7 @@ module From_file = functor(F: S.FILE) -> struct
+         let from_branch = make from in
+         let to_include = BATS.(union (diff t_branch from_branch) (diff from_branch t_branch)) in
+         fun i ->
+-          BATS.fold (fun (_, bat) acc -> acc || (BAT.get bat i <> BAT.unused)) to_include false
++          BATS.fold (fun (_, bat) acc -> acc || (i < BAT.length bat && BAT.get bat i <> BAT.unused)) to_include false
+ 
+   let raw_common ?from ?(raw: 'a) (vhd: fd Vhd.t) =
+     let block_size_sectors_shift = vhd.Vhd.header.Header.block_size_sectors_shift in
+-- 
+2.7.4
+

--- a/ocaml-vhd.spec
+++ b/ocaml-vhd.spec
@@ -2,12 +2,13 @@
 
 Name:           ocaml-vhd
 Version:        0.7.1
-Release:        1
+Release:        2
 Summary:        A pure OCaml library for reading, writing, streaming, converting vhd format files
 License:        LGPL2.1 + OCaml linking exception
 Group:          Development/Other
 URL:            http://github.com/xapi-project/ocaml-vhd
 Source0:        https://github.com/xapi-project/%{name}/archive/%{version}/%{name}-%{version}.tar.gz
+Patch0:         ocaml-vhd-CA-218219.patch
 BuildRoot:      %{_tmppath}/%{name}-%{version}-%{release}
 BuildRequires:  ocaml ocaml-findlib cmdliner-devel ocaml-ounit-devel ocaml-cstruct-devel ocaml-lwt-devel ocaml-uuidm-devel ocaml-camlp4-devel
 BuildRequires:  ocaml-io-page-devel
@@ -29,6 +30,7 @@ developing applications that use %{name}.
 
 %prep
 %setup -q
+%patch0 -p1 -b ~ocaml-vhd-CA-218219.patch
 
 %build
 if [ -x ./configure ]; then
@@ -57,6 +59,8 @@ rm -rf %{buildroot}
 %{_libdir}/ocaml/stublibs/dllvhd*
 
 %changelog
+* Thu Mar 23 2017 Frederico Mazzone <frederico.mazzone@citrix.com> - 0.7.1-2
+- CA-218219: Check index range before accessing
 * Mon Jul 14 2014 John Else <john.else@citrix.com> - 0.7.1-1
 - Update to 0.7.1
 - Fix for VHD trees with nodes of nonequal sizes

--- a/vhd-tool.spec
+++ b/vhd-tool.spec
@@ -3,7 +3,7 @@
 Summary: command-line tools for manipulating and streaming .vhd format files
 Name:    vhd-tool
 Version: 0.7.4
-Release: 4
+Release: 5
 Group:   System/Hypervisor
 License: LGPL+linking exception
 URL:  http://www.xen.org
@@ -60,6 +60,9 @@ rm -rf %{buildroot}
 /opt/xensource/libexec/sparse_dd
 
 %changelog
+* Thu Mar 23 2017 Frederico Mazzone <frederico.mazzone@citrix.com> - 0.7.4-5
+- CA-244698: Use ocaml-vhd-v0.7.1-2, containing patch for CA-218219
+
 * Wed Mar 8 2017 Sharad Yadav <sharad.yadav@citrix.com> - 0.7.4-4
 - Add vhd-tool-CA-236851.patch
 


### PR DESCRIPTION
Create new release of ocaml-vhd and vhd-tool (which will use the
new ocaml-vhd).

Signed-off-by: Frederico Mazzone <frederico.mazzone@citrix.com>